### PR TITLE
Fix: GridMenuIssuerがチェストインベントリになっている問題を修正する

### DIFF
--- a/src/main/kotlin/com/github/karayuu/creategridregionplugin/menu/InventoryProperty.kt
+++ b/src/main/kotlin/com/github/karayuu/creategridregionplugin/menu/InventoryProperty.kt
@@ -1,0 +1,35 @@
+package com.github.karayuu.creategridregionplugin.menu
+
+import org.bukkit.Bukkit
+import org.bukkit.event.inventory.InventoryType
+import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.InventoryHolder
+
+/**
+ * インベントリのタイプまたはサイズを保持しているクラスです。
+ *
+ * @author
+ */
+class InventoryProperty {
+    private val type: InventoryType?
+    private val size: Int?
+
+    private constructor(type: InventoryType?, size: Int?) {
+        this.type = type
+        this.size = size
+    }
+
+    private fun notifyIllegalState(): Nothing = throw IllegalStateException("null has been passed to the constructor!")
+
+    constructor(type: InventoryType): this(type, null)
+
+    constructor(size: Int): this(null, size)
+
+    fun createInventoryWith(inventoryHolder: InventoryHolder, title: String): Inventory = when {
+        this.type == null -> Bukkit.createInventory(inventoryHolder, this.size!!, title)
+        this.size == null -> Bukkit.createInventory(inventoryHolder, this.type, title)
+        else -> notifyIllegalState()
+    }
+
+    fun toSize() = this.size ?: (this.type?.defaultSize ?: notifyIllegalState())
+}

--- a/src/main/kotlin/com/github/karayuu/creategridregionplugin/menu/MenuIssuer.kt
+++ b/src/main/kotlin/com/github/karayuu/creategridregionplugin/menu/MenuIssuer.kt
@@ -1,7 +1,6 @@
 package com.github.karayuu.creategridregionplugin.menu
 
 import com.github.karayuu.creategridregionplugin.menu.component.Button
-import org.bukkit.Bukkit
 import org.bukkit.event.inventory.InventoryCloseEvent
 import org.bukkit.event.inventory.InventoryOpenEvent
 import org.bukkit.event.inventory.InventoryType
@@ -28,8 +27,8 @@ abstract class MenuIssuer: InventoryHolder {
     /** Menuのタイトル */
     abstract val title: String
 
-    /** インベントリのサイズ */
-    open val size = InventoryType.CHEST.defaultSize
+    /** インベントリのサイズまたはタイプを与えるプロパティ */
+    open val inventoryProperty = InventoryProperty(InventoryType.CHEST)
 
     /**
      * 発行したメニューが開かれたときのアクションを実行します
@@ -53,8 +52,8 @@ abstract class MenuIssuer: InventoryHolder {
      * インベントリを取得します。
      * @return inventory
      */
-    override fun getInventory(): Inventory = Bukkit.createInventory(this, size, title).also { inventory ->
-        buttonMap.filterKeys { it < size }.forEach { (slotNumber, button) ->
+    override fun getInventory(): Inventory = inventoryProperty.createInventoryWith(this, title).also { inventory ->
+        buttonMap.filterKeys { it < inventoryProperty.toSize() }.forEach { (slotNumber, button) ->
             inventory.setItem(slotNumber, button.icon.itemStack)
         }
     }

--- a/src/main/kotlin/com/github/karayuu/creategridregionplugin/menu/menus/grid/GridMenuIssuer.kt
+++ b/src/main/kotlin/com/github/karayuu/creategridregionplugin/menu/menus/grid/GridMenuIssuer.kt
@@ -1,5 +1,6 @@
 package com.github.karayuu.creategridregionplugin.menu.menus.grid
 
+import com.github.karayuu.creategridregionplugin.menu.InventoryProperty
 import com.github.karayuu.creategridregionplugin.menu.MenuIssuerWithSound
 import com.github.karayuu.creategridregionplugin.menu.component.Button
 import com.github.karayuu.creategridregionplugin.menu.menus.grid.buttons.*
@@ -18,7 +19,7 @@ import org.bukkit.event.inventory.InventoryType
  */
 class GridMenuIssuer(private val issueTargetPlayer: Player,
                      private val gridSelection: GridSelection) : MenuIssuerWithSound() {
-    override val size = InventoryType.DISPENSER.defaultSize
+    override val inventoryProperty = InventoryProperty(InventoryType.DISPENSER)
 
     override val openingSound = SoundConfiguration(Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1F, 1F)
 


### PR DESCRIPTION
MenuIssuerにインベントリのプロパティを包んだオブジェクトを持たせることで対応